### PR TITLE
EDU_ROBOT_WHEEL_TYPE now evaluated to publish correct footprint

### DIFF
--- a/docker/iot2050/launch_content/eduard-iot2050.launch.py
+++ b/docker/iot2050/launch_content/eduard-iot2050.launch.py
@@ -34,7 +34,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-iot-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+         parameter_file,
+         {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen'      

--- a/docker/ipc127e/launch_content/eduard-ipc127e.launch.py
+++ b/docker/ipc127e/launch_content/eduard-ipc127e.launch.py
@@ -23,7 +23,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-ethernet-gateway-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen'

--- a/docker/ipcbx21a/launch_content/eduard-ipcbx21a.launch.py
+++ b/docker/ipcbx21a/launch_content/eduard-ipcbx21a.launch.py
@@ -23,7 +23,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-ethernet-gateway-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen'

--- a/docker/raspberry/docker-compose.yaml
+++ b/docker/raspberry/docker-compose.yaml
@@ -12,7 +12,8 @@ services:
         mem_limit: 300mb
         environment:
             - EDU_ROBOT_NAMESPACE=${EDU_ROBOT_NAMESPACE}
-            - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}            
+            - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION} 
+            - CYCLONEDDS_URI=/home/user/ros/launch_content/cyclone_profile.xml  
         network_mode: "host"
         command: bash -c 'cd /home/user/ros/launch_content; ros2 launch eduard-360-pi.launch.py'
         volumes:
@@ -33,7 +34,8 @@ services:
         mem_limit: 300mb
         environment:
             - EDU_ROBOT_NAMESPACE=${EDU_ROBOT_NAMESPACE}
-            - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}            
+            - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION} 
+            - CYCLONEDDS_URI=/home/user/ros/launch_content/cyclone_profile.xml  
         network_mode: "host"
         devices:
             - '/dev:/dev'

--- a/docker/raspberry/launch_content/cyclone_profile.xml
+++ b/docker/raspberry/launch_content/cyclone_profile.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CycloneDDS
+  xmlns="https://cdds.io/config"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd"
+>
+    <Domain Id="any">
+        <General>
+            <Interfaces>
+                <!-- Main interface connected to access point usually. -->
+                <NetworkInterface name="eth0" priority="10" multicast="true" presence_required="true"/>
+                <!-- Optional interface wifi card. -->
+                <NetworkInterface name="wlan0" priority="10" multicast="true" presence_required="false"/>
+            </Interfaces>
+            <AllowMulticast>true</AllowMulticast>
+            <MaxMessageSize>65500B</MaxMessageSize>
+        </General>
+    </Domain>
+</CycloneDDS>

--- a/docker/raspberry/launch_content/eduard-360-pi.launch.py
+++ b/docker/raspberry/launch_content/eduard-360-pi.launch.py
@@ -39,7 +39,8 @@ def generate_launch_description():
       name='pi_bot',
       parameters=[
         parameter_file,
-        motor_parameter_file
+        motor_parameter_file,
+        {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
       ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),      
       # prefix=['gdbserver localhost:3000'],

--- a/docker/raspberry_ethernet/launch_content/eduard-raspberry-ethernet.launch.py
+++ b/docker/raspberry_ethernet/launch_content/eduard-raspberry-ethernet.launch.py
@@ -70,7 +70,8 @@ def generate_launch_description():
       name='eduard',
       parameters=[
         parameter_file,
-        motor_parameter_file
+        motor_parameter_file,
+        {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
         # ParameterFile(OpaqueFunction(function=get_motor_parameter_file, args=[LaunchConfiguration('motor_model')]))
       ],
       namespace=edu_robot_namespace,

--- a/documentation/setup/virtualMachine.md
+++ b/documentation/setup/virtualMachine.md
@@ -71,6 +71,7 @@ Guest additions are needed for e.g. fullscreen
    - Add the following at the bottom of the file:
      - For Humble: `source /opt/ros/humble/setup.bash`
      - For Jazzy: `source /opt/ros/jazzy/setup.bash`
+     - Or universally: `source /opt/ros/$ROS_DISTRO/setup.bash` <br>This will automatically detect the installed ROS2 version
 3. Close the terminal and open a new one. Test if the ros commands (e.g. `ros2 topic list`) work.
 
 # 8. Install the Cyclone DDS Middleware

--- a/documentation/setup/virtualMachine.md
+++ b/documentation/setup/virtualMachine.md
@@ -101,7 +101,10 @@ git clone https://github.com/EduArt-Robotik/edu_robot_control.git
    - *xacro* ([link](https://github.com/ros/xacro)):
      - For Humble: `sudo apt install ros-humble-xacro`
      - For Jazzy: `sudo apt install ros-jazzy-xacro`
-5. Change into the root directory of the workspace: `cd ..`
+   - *hardware-interface*
+     - Für Humble: `sudo apt install ros-humble-hardware-interface`
+     - Für Jazzy: `sudo apt install ros-jazzy-hardware-interface`
+5. Change into the root directory of the workspace: `cd ~/ros2`
 6. Build the packages: `colcon build --symlink-install`
 7. Add the workspace to your `bashrc` file
    - Open the file with *Nano*: `nano ~/.bashrc`

--- a/include/edu_robot/bot/eduard.hpp
+++ b/include/edu_robot/bot/eduard.hpp
@@ -23,6 +23,30 @@ struct COLOR {
   };
 };
 
+struct WHEEL {
+  enum TYPE {
+    offroad,  // this is equivalent to skid
+    mecanum
+  };
+
+  static std::string to_string(TYPE t) {
+    switch(t) {
+      case offroad: return "offroad";
+      default:      return "mecanum";
+    }
+  }
+
+  static TYPE from_string(const std::string &s) {
+    std::string lower = s;
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
+
+    if (lower == "offroad") return offroad;
+    else return mecanum;
+  }
+};
+
 class Eduard : public robot::Robot
 {
 public:
@@ -40,7 +64,8 @@ public:
         float y = 0.36f;
       } length;
       float wheel_diameter = 0.1f;
-    } mecanum;    
+    } mecanum;
+    WHEEL::TYPE wheel_type = WHEEL::TYPE::mecanum;    
   };
 
   Eduard(

--- a/launch/eduard-360-pi.launch.py
+++ b/launch/eduard-360-pi.launch.py
@@ -57,7 +57,8 @@ def generate_launch_description():
       name='pi_bot',
       parameters=[
         parameter_file,
-        OpaqueFunction(function=get_motor_parameter_file, args=[LaunchConfiguration('motor_model')])
+        OpaqueFunction(function=get_motor_parameter_file, args=[LaunchConfiguration('motor_model')]),
+        {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
       ],
       namespace=edu_robot_namespace,      
       # prefix=['gdbserver localhost:3000'],

--- a/launch/eduard-iot2050.launch.py
+++ b/launch/eduard-iot2050.launch.py
@@ -24,7 +24,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-iot-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen',

--- a/launch/eduard-ipc127e.launch.py
+++ b/launch/eduard-ipc127e.launch.py
@@ -24,7 +24,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-ethernet-gateway-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen',

--- a/launch/eduard-ipcbx21a.launch.py
+++ b/launch/eduard-ipcbx21a.launch.py
@@ -24,7 +24,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-ethernet-gateway-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen'

--- a/launch/eduard-lifetwin.launch.py
+++ b/launch/eduard-lifetwin.launch.py
@@ -23,7 +23,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='ethernet-gateway',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       remappings=[
         ('cmd_vel', 'not_used/edu_robot/cmd_vel')  

--- a/launch/eduard-raspberry-pi.launch.py
+++ b/launch/eduard-raspberry-pi.launch.py
@@ -24,7 +24,10 @@ def generate_launch_description():
       package='edu_robot',
       executable='eduard-ethernet-gateway-bot',
       name='eduard',
-      parameters=[parameter_file],
+      parameters=[
+          parameter_file,
+          {'wheel_type': EnvironmentVariable('EDU_ROBOT_WHEEL_TYPE', default_value='mecanum')}
+      ],
       namespace=EnvironmentVariable('EDU_ROBOT_NAMESPACE', default_value="eduard"),
       # prefix=['gdbserver localhost:3000'],
       output='screen'

--- a/src/lib/bot/eduard.cpp
+++ b/src/lib/bot/eduard.cpp
@@ -34,6 +34,8 @@ static Eduard::Parameter get_robot_ros_parameter(rclcpp::Node& ros_node)
   ros_node.declare_parameter<float>("mecanum.length.y", parameter.mecanum.length.y);
   ros_node.declare_parameter<float>("mecanum.wheel_diameter", parameter.mecanum.wheel_diameter);
 
+  ros_node.declare_parameter<std::string>("wheel_type", WHEEL::to_string(parameter.wheel_type));
+
   // Reading Parameters
   parameter.skid.length.x = ros_node.get_parameter("skid.length.x").as_double();
   parameter.skid.length.y = ros_node.get_parameter("skid.length.y").as_double();
@@ -42,6 +44,8 @@ static Eduard::Parameter get_robot_ros_parameter(rclcpp::Node& ros_node)
   parameter.mecanum.length.x = ros_node.get_parameter("mecanum.length.x").as_double();
   parameter.mecanum.length.y = ros_node.get_parameter("mecanum.length.y").as_double();
   parameter.mecanum.wheel_diameter = ros_node.get_parameter("mecanum.wheel_diameter").as_double();
+
+  parameter.wheel_type = WHEEL::from_string(ros_node.get_parameter("wheel_type").as_string());
 
   return parameter;
 }
@@ -109,11 +113,20 @@ void Eduard::initialize(eduart::robot::HardwareComponentFactory& factory)
   imu_parameter.rotated_frame = getFrameIdPrefix() + Robot::_parameter.tf.base_frame;
   imu_parameter = SensorImu::get_parameter("imu", imu_parameter, *this);
 
+  // compute imu translation based on wheel type and wheel diameter
+  double imuZ = 0.0;
+  if (_parameter.wheel_type == WHEEL::TYPE::offroad) {
+    imuZ = _parameter.skid.wheel_diameter / 2;
+  } else {
+    imuZ = _parameter.mecanum.wheel_diameter / 2;
+  }
+  imuZ -= 0.02; // according to urdf robot model, the wheels are mounted 0.02 above base_link; base_link itself has no translation (only rotation) in reference to imu/base
+
   auto imu_sensor = std::make_shared<robot::SensorImu>(
     "imu",
     getFrameIdPrefix() + "imu/base",
     getFrameIdPrefix() + Robot::_parameter.tf.footprint_frame,
-    tf2::Transform(tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(0.0, 0.0, 0.04)),
+    tf2::Transform(tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(0.0, 0.0, imuZ)),
     imu_parameter,
     getTfBroadcaster(),
     *this,


### PR DESCRIPTION
This fix implements the evaluation / utilization of the environment variable EDU_ROBOT_WHEEL_TYPE
to correctly publish the translation between `base_footprint` and `imu/base` in regard of z.

For this:
 - the (string) parameter `wheel_type` was introduced
 - all relevant launch files map the parameter `wheel_type` on the environment variable EDU_ROBOT_WHEEL_TYPE
 - the parameter is evaluated in the class `Eduard`
 - the transformation from `base_footprint` to `imu/base` is calculated as:
   `x = 0`
   `y = 0`
   `z = (wheel_diameter / 2.0) - 0.02` 
   The subtraction of 0.02 originates from the urdf robot model, in which the motor axle is mounted 0.02 above base_link and hence imu/base, since there is no translation between base_link and imu/base.
- per default "mecanum" is chosen when `wheel_type` is not provided or does not hold a valid value