### PR TITLE
Added compatibility with ROS2 Lyrical

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(edu_robot)
+
+if (POLICY CMP0167)
+    cmake_policy(SET CMP0167 OLD)
+endif ()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -std=c++1z)# -O2)

--- a/include/edu_robot/hardware/communicator_node.hpp
+++ b/include/edu_robot/hardware/communicator_node.hpp
@@ -9,6 +9,7 @@
 #include "edu_robot/hardware/rx_data_endpoint.hpp"
 #include "edu_robot/hardware/communicator.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <memory>

--- a/include/edu_robot/robot.hpp
+++ b/include/edu_robot/robot.hpp
@@ -31,7 +31,7 @@
 #include <rclcpp/service.hpp>
 #include <rclcpp/subscription.hpp>
 #include <rclcpp/timer.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <geometry_msgs/msg/twist.hpp>

--- a/include/edu_robot/sensor.hpp
+++ b/include/edu_robot/sensor.hpp
@@ -9,7 +9,7 @@
 #include <edu_robot/processing_component/processing_component.hpp>
 
 #include <rclcpp/time.hpp>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <string>

--- a/include/edu_robot/sensor_imu.hpp
+++ b/include/edu_robot/sensor_imu.hpp
@@ -14,7 +14,7 @@
 
 #include <rclcpp/clock.hpp>
 #include <rclcpp/publisher.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 
 #include <memory>

--- a/include/edu_robot/sensor_point_cloud.hpp
+++ b/include/edu_robot/sensor_point_cloud.hpp
@@ -12,7 +12,7 @@
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 
 namespace eduart {
 namespace robot {

--- a/include/edu_robot/sensor_range.hpp
+++ b/include/edu_robot/sensor_range.hpp
@@ -14,9 +14,9 @@
 #include <rclcpp/clock.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/publisher.hpp>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2_ros/transform_listener.h>
-#include <tf2_ros/buffer.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2_ros/transform_listener.hpp>
+#include <tf2_ros/buffer.hpp>
 
 #include <sensor_msgs/msg/range.hpp>
 

--- a/src/lib/action/CMakeLists.txt
+++ b/src/lib/action/CMakeLists.txt
@@ -4,18 +4,15 @@ add_library(eduart-action
 )
 target_link_libraries(eduart-action
   "${cpp_typesupport_target}"
+  rclcpp::rclcpp
+  "${sensor_msgs_TARGETS}"
+  "${diagnostic_msgs_TARGETS}"
+  diagnostic_updater::diagnostic_updater
 )
 target_compile_features(eduart-action PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(eduart-action PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(
-  eduart-action
-  "rclcpp"
-  "sensor_msgs"
-  "diagnostic_msgs"
-  "diagnostic_updater"  
 )
 list(APPEND BUILT_LIBRARIES eduart-action)
 

--- a/src/lib/algorithm/CMakeLists.txt
+++ b/src/lib/algorithm/CMakeLists.txt
@@ -6,16 +6,13 @@ add_library(eduart-algorithm
 target_link_libraries(eduart-algorithm
   "${cpp_typesupport_target}"
   Eigen3::Eigen
+  "${geometry_msgs_TARGETS}"
+  tf2::tf2
 )
 target_compile_features(eduart-algorithm PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(eduart-algorithm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(
-  eduart-algorithm
-  "geometry_msgs"
-  "tf2"
 )
 list(APPEND BUILT_LIBRARIES eduart-algorithm)
 

--- a/src/lib/bot/eduard.cpp
+++ b/src/lib/bot/eduard.cpp
@@ -7,7 +7,7 @@
 #include <edu_robot/sensor_range.hpp>
 #include <edu_robot/sensor_imu.hpp>
 
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <Eigen/src/Core/Matrix.h>

--- a/src/lib/bot/rebel_move.cpp
+++ b/src/lib/bot/rebel_move.cpp
@@ -7,7 +7,7 @@
 #include <edu_robot/sensor_imu.hpp>
 #include <edu_robot/sensor_point_cloud.hpp>
 
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <Eigen/src/Core/Matrix.h>

--- a/src/lib/bot/universal_bot.cpp
+++ b/src/lib/bot/universal_bot.cpp
@@ -13,7 +13,7 @@
 #include <string>
 
 #include <rclcpp/logging.hpp>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <Eigen/src/Core/Matrix.h>
 

--- a/src/lib/diagnostic/CMakeLists.txt
+++ b/src/lib/diagnostic/CMakeLists.txt
@@ -7,12 +7,8 @@ target_include_directories(eduart-diagnostic PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(eduart-diagnostic
-
-)
-ament_target_dependencies(
-  eduart-diagnostic
-  "diagnostic_updater"
-  "diagnostic_msgs"
+  diagnostic_updater::diagnostic_updater
+  "${diagnostic_msgs_TARGETS}"
 )
 list(APPEND BUILT_LIBRARIES eduart-diagnostic)
 

--- a/src/lib/hardware/can_gateway/CMakeLists.txt
+++ b/src/lib/hardware/can_gateway/CMakeLists.txt
@@ -15,16 +15,14 @@ target_link_libraries(eduart-hardware-can
   eduart-algorithm
   eduart-robot
   eduart-hardware
+  tf2::tf2
+  tf2_ros::tf2_ros
+  tf2_sensor_msgs::tf2_sensor_msgs
 )
 target_compile_features(eduart-hardware-can PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(eduart-hardware-can PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(eduart-hardware-can
-  "tf2"
-  "tf2_ros"
-  "tf2_sensor_msgs"
 )
 list(APPEND BUILT_LIBRARIES eduart-hardware-can)
 
@@ -40,10 +38,8 @@ if (HAVE_GPIOD)
   target_link_libraries(ros2-control-eduard-raspberry
     gpiodcxx
     gpiod
-  )
-  ament_target_dependencies(ros2-control-eduard-raspberry
-    "pluginlib"
-    "hardware_interface"
+    pluginlib::pluginlib
+    hardware_interface::hardware_interface
   )
   list(APPEND BUILT_LIBRARIES ros2-control-eduard-raspberry)
 endif()

--- a/src/lib/hardware/can_gateway/sensor_tof_ring_hardware.cpp
+++ b/src/lib/hardware/can_gateway/sensor_tof_ring_hardware.cpp
@@ -8,7 +8,7 @@
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 

--- a/src/lib/hardware/can_gateway/sensor_virtual_range.cpp
+++ b/src/lib/hardware/can_gateway/sensor_virtual_range.cpp
@@ -4,7 +4,7 @@
 #include <edu_robot/message/geometry.hpp>
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <Eigen/Geometry>
 

--- a/src/lib/hardware/igus/CMakeLists.txt
+++ b/src/lib/hardware/igus/CMakeLists.txt
@@ -13,9 +13,7 @@ target_link_libraries(igus
   eduart-robot
   eduart-hardware
   eduart-hardware-can
-)
-ament_target_dependencies(igus
-  "rclcpp"
+  rclcpp::rclcpp
 )
 list(APPEND BUILT_LIBRARIES igus)
 

--- a/src/lib/hardware/iot_shield/CMakeLists.txt
+++ b/src/lib/hardware/iot_shield/CMakeLists.txt
@@ -44,10 +44,8 @@ if (HAVE_MRAA)
   )
   target_link_libraries(ros2-control-eduard-iot
     mraa
-  )
-  ament_target_dependencies(ros2-control-eduard-iot
-    "pluginlib"
-    "hardware_interface"
+    pluginlib::pluginlib
+    hardware_interface::hardware_interface
   )
   list(APPEND BUILT_LIBRARIES ros2-control-eduard-iot)
 endif()

--- a/src/lib/processing_component/CMakeLists.txt
+++ b/src/lib/processing_component/CMakeLists.txt
@@ -7,17 +7,15 @@ add_library(processing-component
 target_link_libraries(processing-component
   Eigen3::Eigen
   "${cpp_typesupport_target}"
+  rclcpp::rclcpp
+  "${nav_msgs_TARGETS}"
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 target_compile_features(processing-component PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(processing-component PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(
-  processing-component
-  "rclcpp"
-  "nav_msgs"
-  "tf2_geometry_msgs"
 )
 list(APPEND BUILT_LIBRARIES processing-component)
 

--- a/src/lib/processing_component/odometry_estimator.cpp
+++ b/src/lib/processing_component/odometry_estimator.cpp
@@ -2,7 +2,7 @@
 #include "edu_robot/processing_component/processing_component.hpp"
 
 #include <Eigen/Geometry> 
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 
 namespace eduart {
 namespace robot {

--- a/src/lib/robot/CMakeLists.txt
+++ b/src/lib/robot/CMakeLists.txt
@@ -18,25 +18,22 @@ target_link_libraries(eduart-robot
   eduart-action
   eduart-diagnostic
   "${cpp_typesupport_target}"
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_ros::tf2_ros
+  tf2_geometry_msgs::tf2_geometry_msgs
+  "${nav_msgs_TARGETS}"
+  "${std_msgs_TARGETS}"
+  "${geometry_msgs_TARGETS}"
+  "${sensor_msgs_TARGETS}"
+  diagnostic_updater::diagnostic_updater
+  "${diagnostic_msgs_TARGETS}"
+  "${std_srvs_TARGETS}"
 )
 target_compile_features(eduart-robot PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(eduart-robot PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(
-  eduart-robot
-  "rclcpp"
-  "tf2"
-  "tf2_ros"
-  "tf2_geometry_msgs"
-  "nav_msgs"
-  "std_msgs"
-  "geometry_msgs"
-  "sensor_msgs"
-  "diagnostic_updater"
-  "diagnostic_msgs"
-  "std_srvs"
 )
 list(APPEND BUILT_LIBRARIES eduart-robot)
 

--- a/src/lib/robot/executer.cpp
+++ b/src/lib/robot/executer.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <thread>
 
+#include <rclcpp/rclcpp.hpp>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -6,9 +6,7 @@ add_executable(eduard-iot-bot
 target_link_libraries(eduard-iot-bot
   eduart-iotbot-shield
   eduart-bot
-)
-ament_target_dependencies(eduard-iot-bot
-  "rclcpp"
+  rclcpp::rclcpp
 )
 set(BUILT_NODES ${BUILT_NODES} "eduard-iot-bot")
 
@@ -19,9 +17,7 @@ add_executable(eduard-ethernet-gateway-bot
 target_link_libraries(eduard-ethernet-gateway-bot
   eduart-ethernet-gateway
   eduart-bot
-)
-ament_target_dependencies(eduard-ethernet-gateway-bot
-  "rclcpp"
+  rclcpp::rclcpp
 )
 set(BUILT_NODES ${BUILT_NODES} "eduard-ethernet-gateway-bot")
 
@@ -32,9 +28,7 @@ add_executable(universal-ethernet-gateway-bot
 target_link_libraries(universal-ethernet-gateway-bot
   eduart-ethernet-gateway
   eduart-bot
-)
-ament_target_dependencies(universal-ethernet-gateway-bot
-  "rclcpp"
+  rclcpp::rclcpp
 )
 set(BUILT_NODES ${BUILT_NODES} "universal-ethernet-gateway-bot")
 
@@ -45,9 +39,7 @@ add_executable(eduard-360-pi-bot
 target_link_libraries(eduard-360-pi-bot
   eduart-bot
   eduart-hardware-can
-)
-ament_target_dependencies(eduard-360-pi-bot
-  "rclcpp"
+  rclcpp::rclcpp
 )
 set(BUILT_NODES ${BUILT_NODES} "eduard-360-pi-bot")
 
@@ -58,9 +50,7 @@ add_executable(universal-360-pi-bot
 target_link_libraries(universal-360-pi-bot
   eduart-bot
   eduart-hardware-can
-)
-ament_target_dependencies(universal-360-pi-bot
-  "rclcpp"
+  rclcpp::rclcpp
 )
 set(BUILT_NODES ${BUILT_NODES} "universal-360-pi-bot")
 
@@ -72,9 +62,7 @@ target_link_libraries(rebel-move-360-pi-bot
   igus
   eduart-bot
   eduart-hardware-can
-)
-ament_target_dependencies(rebel-move-360-pi-bot
-  "rclcpp"
+  rclcpp::rclcpp
 )
 set(BUILT_NODES ${BUILT_NODES} "rebel-move-360-pi-bot")
 

--- a/src/test/unit_test/CMakeLists.txt
+++ b/src/test/unit_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 
 # Find Google Test
 find_package(ament_cmake_gtest REQUIRED)


### PR DESCRIPTION
This PR adds compatibility with ROS2 Lyrical while retaining compatibility with ROS2 Jazzy and Kilted.

Changes:
- replaced `ament_target_dependencies` by `target_link_librariers`
- added missing headers
- raised minimum required cmake version from 3.8 to 3.10
- added CMP0167 policy
- replaced some ros2 specific *.h headers with their *.hpp counterpart 